### PR TITLE
Use portable-atomic to support PowerPC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ contents are never required to be entirely resident in memory all at once.
 [dependencies]
 filetime = "0.2"
 futures-core = "0.3"
+portable-atomic = "1"
 tokio = { version = "1", features = ["fs", "io-util", "rt"] }
 tokio-stream = "0.1"
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -3,11 +3,12 @@ use std::{
     collections::VecDeque,
     path::Path,
     pin::Pin,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+    sync::Arc,
     task::{Context, Poll},
+};
+use portable_atomic::{
+    AtomicU64,
+    Ordering,
 };
 use tokio::{
     io::{self, AsyncRead as Read, AsyncReadExt},


### PR DESCRIPTION
Use the portable-atomic crate to fix build failure on PowerPC target that does not support 64-bit atomics natively:

```
error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
 --> src/archive.rs:7:18
  |
7 |         atomic::{AtomicU64, Ordering},
  |                  ^^^^^^^^^
  |                  |
  |                  no `AtomicU64` in `sync::atomic`
  |                  help: a similar name exists in the module: `AtomicU32`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `tokio-tar` (lib) due to 1 previous error
```