### PR TITLE
Include archives in crates.io uploads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT/Apache-2.0"
 keywords = ["tar", "tarfile", "encoding"]
 readme = "README.md"
 edition = "2018"
-exclude = ["tests/archives/*"]
 
 description = """
 A Rust implementation of an async TAR file reader and writer. This library does not


### PR DESCRIPTION
In Debian we package rust crates from crates.io. Having the archives not available does mean I can't run tests locally