### PR TITLE
Actually include the underlying error in the fmt

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,8 +28,8 @@ impl error::Error for TarError {
 }
 
 impl fmt::Display for TarError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.desc.fmt(f)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.io)
     }
 }
 


### PR DESCRIPTION
Include source error description in the `TarError` description to avoid callers hiding/swallowing the actual cause of the TarError.

Without this you get errors like:

> Error: status: Unknown, message: "failed to assemble image: failed to unpack `/tmp/oci-assemble-379e296b-2530-416b-b483-e77549209ef3/image/root/usr/local/bin/google-cloud-sdk/platform/gsutil/gslib/tests/test_data/test.txt`


With this you get (more materially useful) errors like


> Error: status: Unknown, message: "failed to assemble image: failed to unpack `/tmp/oci-assemble-379e296b-2530-416b-b483-e77549209ef3/image/root/usr/local/bin/google-cloud-sdk/platform/gsutil/gslib/tests/test_data/test.txt`: No space left on device (os error 28)", details: [], metadata: MetadataMap { headers: {} }
